### PR TITLE
Add ability to access `message_id` if specified in the callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Ability to specify `last_id` of a channel
+- Get access to `message_id` if specified in the callback

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The API is mostly equivalent with the JavaScript client:
 
 ```ruby
 client = MessageBus::Client.new('http://chat.samsaffron.com/')
-client.subscribe('/message') do |payload|
+client.subscribe('/message') do |payload, message_id|
   # Do stuff
 end
 

--- a/lib/message_bus/client/message_handler.rb
+++ b/lib/message_bus/client/message_handler.rb
@@ -5,9 +5,9 @@ module MessageBus::Client::MessageHandler
       self.last_id = last_id
     end
 
-    def callback(payload)
+    def callback(payload, message_id)
       callbacks.each do |callback|
-        callback.call(payload)
+        callback.call(payload, message_id)
       end
     end
   end
@@ -82,8 +82,9 @@ module MessageBus::Client::MessageHandler
     subscription = @subscribed_channels[message['channel']]
     return unless subscription
 
-    subscription.last_id = message['message_id']
-    subscription.callback(message['data'])
+    message_id = message['message_id']
+    subscription.last_id = message_id
+    subscription.callback(message['data'], message_id)
   end
 
   def handle_status_message(message)

--- a/spec/message_bus/client_spec.rb
+++ b/spec/message_bus/client_spec.rb
@@ -113,4 +113,20 @@ RSpec.describe MessageBus::Client do
     subject.resume
     expect(result).to eq(true)
   end
+
+  it 'allows subscription exposing the message_id' do
+    subject.start
+
+    text = "Hello World! #{Random.rand}"
+    result = false
+    subject.subscribe('/message') do |payload, message_id|
+      result = true if payload['data'] == text
+      expect(message_id).to be_an Integer
+    end
+
+    until result
+      write_message(text) # Keep writing because the message bus might not have started.
+      sleep(1)
+    end
+  end
 end


### PR DESCRIPTION
This is useful when apps save the last message received, so that when they boot up again they can resume.